### PR TITLE
Move exports to the bottom of their respective files

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -11,8 +11,6 @@ import {defineProperty, objCreate} from './es5';
 import Compiler from './compiler';
 import parser from 'intl-messageformat-parser';
 
-export default MessageFormat;
-
 // -- MessageFormat --------------------------------------------------------
 
 function MessageFormat(message, locales, formats) {
@@ -263,3 +261,5 @@ MessageFormat.prototype._resolveLocale = function (locales) {
         locales.join(', ') + ', or the default locale: ' + defaultLocale
     );
 };
+
+export default MessageFormat;

--- a/src/es5.js
+++ b/src/es5.js
@@ -8,8 +8,6 @@ See the accompanying LICENSE file for terms.
 
 import {hop} from './utils';
 
-export {defineProperty, objCreate};
-
 // Purposely using the same implementation as the Intl.js `Intl` polyfill.
 // Copyright 2013 Andy Earnshaw, MIT License
 
@@ -45,3 +43,5 @@ var objCreate = Object.create || function (proto, props) {
 
     return obj;
 };
+
+export {defineProperty, objCreate};


### PR DESCRIPTION
Currently, the location of the `exports` in `intl-messageformat` is causing issues with other libraries that depend on this project. See yahoo/ember-intl#249 for more details.

In short, all of the exported functions are `undefined` if left at the top of the file. Moving them to the end of the file fixes the issue.