### PR TITLE
Fix rendering of formatted Integer 0

### DIFF
--- a/src/compiler.js
+++ b/src/compiler.js
@@ -156,7 +156,7 @@ function StringFormat(id) {
 }
 
 StringFormat.prototype.format = function (value) {
-    if (!value) {
+    if (!value && value !== 0) {
         return '';
     }
 

--- a/tests/index.js
+++ b/tests/index.js
@@ -112,6 +112,18 @@ describe('IntlMessageFormat', function () {
         });
     });
 
+    describe('using a string pattern', function () {
+        it('should render integer 0 number', function () {
+            var mf = new IntlMessageFormat('Осталось попыток: {TRIES_LEFT} из {TRIES_OVERALL}');
+            var output = mf.format({
+                TRIES_LEFT: 0,
+                TRIES_OVERALL: 3
+            });
+
+            expect(output).to.equal('Осталось попыток: 0 из 3');
+        });
+    });
+
     describe('and plurals under the Arabic locale', function () {
         var msg = '' +
             'I have {numPeople, plural,' +


### PR DESCRIPTION
We found in our app that integer 0 (which was quite rare case) was not rendering, when other integers worked very well.
Here is the output of the test which represents the error we had:

![screen shot 2016-03-18 at 15 14 43](https://cloud.githubusercontent.com/assets/1443567/13880515/d693b74c-ed1c-11e5-9693-8fa9067c6985.png)

Source of the test you can find in PR.

This PR can introduce a breaking change for some users who relied that 0 will not be rendered, but I think it's quite risky to assume such things. I think this PR should be applied because you expect that if Number(5) works Number(0) should also work.

WDYT?