### PR TITLE
Fixed formatting of 0 number literal

### DIFF
--- a/src/compiler.js
+++ b/src/compiler.js
@@ -156,11 +156,11 @@ function StringFormat(id) {
 }
 
 StringFormat.prototype.format = function (value) {
-    if (!value) {
-        return '';
+    if (value || value === 0) {
+        return typeof value === 'string' ? value : String(value);
     }
 
-    return typeof value === 'string' ? value : String(value);
+    return '';
 };
 
 function PluralFormat(id, useOrdinal, offset, options, pluralFn) {


### PR DESCRIPTION
I found this issue when using [ember-intl](https://github.com/jasonmit/ember-intl). With the following:

**Template**
`{{t 'numItems' num=0}}`

**Translation**
`"numItems": "There are ({num}) items"`

The rendered string was `There are () items` whereas the expected output is `There are (0) items`. This PR allows intl-messageformat to correctly render the literal `0`.