### PR TITLE
fix: consuming using jsnext:main fails

### DIFF
--- a/src/es5.js
+++ b/src/es5.js
@@ -8,8 +8,6 @@ See the accompanying LICENSE file for terms.
 
 import {hop} from './utils';
 
-export {defineProperty, objCreate};
-
 // Purposely using the same implementation as the Intl.js `Intl` polyfill.
 // Copyright 2013 Andy Earnshaw, MIT License
 
@@ -45,3 +43,5 @@ var objCreate = Object.create || function (proto, props) {
 
     return obj;
 };
+
+export {defineProperty, objCreate};


### PR DESCRIPTION
The export command is executed before the definition of  defineProperty & objCreate so when consuming the src module using jsnext:main in webpack + babel, our build fails due to undefined defineProperty & objCreate. Moving the export to the bottom of the file solves the issue.