### PR TITLE
Adding an example

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,44 @@ console.log(msg.format({numPhotos: 1000})); // => "You have 1,000 photos."
 _Note: how when `numPhotos` was `1000`, the number is formatted with the correct thousands separator._
 
 
+### Plural Label With Templates
+
+```
+You have {numPhotos, plural,
+    =0 {no photos.}
+    =1 {one photo.}
+    other {# photos.}
+}
+```
+
+```js
+var MESSAGES = {
+    photos: '...', // String from code block above.
+    ...
+};
+
+global.Intl.MessageFormat = require('intl-messageformat');
+global.i18n = { MESSAGES }
+
+var msg = new IntlMessageFormat(MESSAGES.photos, 'en-US');
+```
+
+Template file;
+
+```
+<!DOCTYPE html>
+<html>
+  <head>
+  </head>
+  <body>
+    <%- new Intl.MessageFormat(i18n.MESSAGES['en-US'].NUM_PHOTOS, 'en-US').format({numPhotos: 1000}) %> <!-- => "You have 1,000 photos." -->
+  </body>
+</html>
+```
+
+_Note: The number is formatted with the correct thousands separator._
+
+
 License
 -------
 

--- a/README.md
+++ b/README.md
@@ -277,10 +277,7 @@ var msg = new IntlMessageFormat(MESSAGES.photos, 'en-US');
 Template file;
 
 ```
-<!DOCTYPE html>
 <html>
-  <head>
-  </head>
   <body>
     <%- new Intl.MessageFormat(i18n.MESSAGES['en-US'].NUM_PHOTOS, 'en-US').format({numPhotos: 1000}) %> <!-- => "You have 1,000 photos." -->
   </body>


### PR DESCRIPTION
Adding an example which explains how to use `intl-messageformat` together with JavaScript Template Engines.