### PR TITLE
Change import directory: `lib` does not exist

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 'use strict';
 
-var IntlMessageFormat = require('./lib/main')['default'];
+var IntlMessageFormat = require('./src/main')['default'];
 
 // Add all locale data to `IntlMessageFormat`. This module will be ignored when
 // bundling for the browser with Browserify/Webpack.


### PR DESCRIPTION
This change fixes half of the problem. The other half is that `src` isn't included in the npm distribution.