### PR TITLE
Bump Travis CI settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: node_js
 node_js:
-- "0.10"
-- "0.12"
+- "4"
+- "6"
+- "8"
 script: npm run travis
 notifications:
   email:


### PR DESCRIPTION
- Drop Node.js v0.10 and v0.12
- Add Node.js v4, v6, and v8