### PR TITLE
Update intl-messageformat-parser to lastest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "intl-messageformat",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Formats ICU Message strings with number, date, plural, and select placeholders to create localized messages.",
   "keywords": [
     "i18n",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "intl-messageformat",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "Formats ICU Message strings with number, date, plural, and select placeholders to create localized messages.",
   "keywords": [
     "i18n",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "./lib/locales.js": false
   },
   "dependencies": {
-    "intl-messageformat-parser": "1.2.0"
+    "intl-messageformat-parser": "1.4.0"
   },
   "devDependencies": {
     "benchmark": "^1.0.0",


### PR DESCRIPTION
Due to the PR https://github.com/yahoo/intl-messageformat-parser/pull/15

add the missing sourcemap files to intl-messageformat-parser. 
please accept this pr to update intl-messageformat-parser to lastest version,  and publish a new npm. 
this will solve the deps missing sourcemap bug.